### PR TITLE
[Feat] 매장 상세 API에 즐겨찾기 상태 연동

### DIFF
--- a/src/main/java/com/example/kakao_login/mapper/StoreDetailMapper.java
+++ b/src/main/java/com/example/kakao_login/mapper/StoreDetailMapper.java
@@ -87,14 +87,25 @@ public class StoreDetailMapper {
     }
 
     /**
+     * 사용자 컨텍스트 생성
+     * @param userId 사용자 ID
+     * @param isFavorite 즐겨찾기 여부
+     * @param hasCoupon 쿠폰 보유 여부
+     * @return 사용자 컨텍스트
+     */
+    public StoreDetailResponse.UserContext createUserContext(String userId, boolean isFavorite, boolean hasCoupon) {
+        return StoreDetailResponse.UserContext.builder()
+            .isFavorite(isFavorite)
+            .hasCoupon(hasCoupon)
+            .build();
+    }
+
+    /**
      * 기본 사용자 컨텍스트 생성 (향후 확장용)
      * @param userId 사용자 ID
      * @return 기본 사용자 컨텍스트
      */
     public StoreDetailResponse.UserContext createDefaultUserContext(String userId) {
-        return StoreDetailResponse.UserContext.builder()
-            .isFavorite(false) // TODO: 즐겨찾기 서비스 연동
-            .hasCoupon(false)  // TODO: 쿠폰 서비스 연동
-            .build();
+        return createUserContext(userId, false, false);
     }
 }

--- a/src/main/java/com/example/kakao_login/service/StoreDetailService.java
+++ b/src/main/java/com/example/kakao_login/service/StoreDetailService.java
@@ -35,6 +35,7 @@ public class StoreDetailService {
     private final MenuItemRepository menuItemRepository;
     private final EarlybirdDealRepository dealRepository;
     private final StoreReviewRepository storeReviewRepository;
+    private final UserFavoriteService userFavoriteService;
     private final StoreDetailMapper mapper;
 
     /**
@@ -66,7 +67,7 @@ public class StoreDetailService {
             averageRating = Math.round(averageRating * 10.0) / 10.0; // 소수점 1자리
 
             // 4. 사용자별 컨텍스트 생성
-            StoreDetailResponse.UserContext userContext = createUserContext(userId);
+            StoreDetailResponse.UserContext userContext = createUserContext(userId, storeId);
 
             // 5. DTO 변환 (Mapper에 위임)
             StoreDetailResponse response = mapper.toStoreDetailResponse(
@@ -129,10 +130,14 @@ public class StoreDetailService {
     /**
      * 사용자별 컨텍스트 정보 생성
      * @param userId 사용자 ID
+     * @param storeId 매장 ID
      * @return 사용자 컨텍스트
      */
-    private StoreDetailResponse.UserContext createUserContext(String userId) {
-        // 현재는 기본값, 향후 즐겨찾기/쿠폰 서비스 연동
-        return mapper.createDefaultUserContext(userId);
+    private StoreDetailResponse.UserContext createUserContext(String userId, String storeId) {
+        // 즐겨찾기 상태 조회
+        boolean isFavorite = userFavoriteService.isFavorite(userId, storeId);
+        
+        // 쿠폰 상태는 기본값 (향후 쿠폰 서비스 연동)
+        return mapper.createUserContext(userId, isFavorite, false);
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

* 매장 상세 조회 시 사용자별 즐겨찾기 상태 표시 기능 구현

---

### ✅ 주요 변경 사항

#### �� 매장 상세 API + 즐겨찾기 연동

* **StoreDetailService 업데이트**
  - `UserFavoriteService` 주입하여 즐겨찾기 상태 조회
  - `createUserContext`에서 실시간 즐겨찾기 상태 확인
  - 사용자별 개인화된 즐겨찾기 정보 제공

* **StoreDetailMapper 업데이트**
  - `createUserContext` 메서드에 즐겨찾기 상태 매핑 로직 추가
  - 기존 `createDefaultUserContext` 메서드 리팩토링
  - 재사용 가능한 매핑 구조로 개선

#### 🎯 API 응답 구조

* **매장 상세 API**: `GET /api/v1/stores/{storeId}`
  ```json
  {
    "user_context": {
      "is_favorite": true,  // 실시간 즐겨찾기 상태
      "has_coupon": false   // 향후 쿠폰 서비스 연동 예정
    }
  }
  ```

* **즐겨찾기 API**: `POST/DELETE /api/v1/stores/{storeId}/favorite`
  - 매장 상세 API와 완벽 연동
  - 실시간 상태 동기화

#### 🧪 통합 테스트 결과

* **user123**: `test-store-real-001` 즐겨찾기 상태 확인 ✅
* **user456**: 즐겨찾기 추가 → 매장 상세에서 상태 변경 확인 ✅
* **user456**: 즐겨찾기 삭제 → 매장 상세에서 상태 변경 확인 ✅

---

### ⚙️ 변경된 파일

* `src/main/java/com/example/kakao_login/service/StoreDetailService.java`
  - UserFavoriteService 주입 및 즐겨찾기 상태 조회 로직 추가
* `src/main/java/com/example/kakao_login/mapper/StoreDetailMapper.java`
  - 즐겨찾기 상태 매핑 로직 추가 및 메서드 리팩토링

---

### 💡 기술적 개선사항

* **실시간 상태 동기화**: 즐겨찾기 변경 시 매장 상세 API에서 즉시 반영
* **사용자별 개인화**: 동일 매장이라도 사용자마다 다른 즐겨찾기 상태 표시
* **성능 최적화**: 기존 매장 상세 조회 로직에 최소한의 추가 쿼리만 발생
* **확장성**: 향후 쿠폰, 리뷰 등 다른 사용자별 정보도 쉽게 추가 가능

---

### �� 사용자 경험 개선

* 매장 상세 페이지에서 즉시 즐겨찾기 상태 확인 가능
* 즐겨찾기 추가/삭제 후 페이지 새로고침 없이 상태 반영
* 사용자별 맞춤형 매장 정보 제공

---

### 💬 기타 참고 사항

* 기존 `UserContext.is_favorite` 필드 활용으로 DTO 변경 최소화
* `X-User-Id` 헤더 기반 사용자 인증 유지
* 향후 쿠폰 서비스 연동 시 `has_coupon` 필드 활용 예정