### PR TITLE
feat: 오늘의 인기 매장 API 구현

### DIFF
--- a/src/main/java/com/example/kakao_login/controller/StoreDetailController.java
+++ b/src/main/java/com/example/kakao_login/controller/StoreDetailController.java
@@ -2,11 +2,14 @@ package com.example.kakao_login.controller;
 
 import com.example.kakao_login.common.ApiResponse;
 import com.example.kakao_login.dto.store.StoreDetailResponse;
+import com.example.kakao_login.dto.store.TodaysPopularStoreResponse;
 import com.example.kakao_login.service.StoreDetailService;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,5 +39,30 @@ public class StoreDetailController {
     ) {
         StoreDetailResponse response = storeDetailService.getStoreDetail(storeId, userId);
         return ApiResponse.success(response);
+    }
+
+    /**
+     * 오늘의 인기 매장 조회
+     * @return 오늘의 인기 매장 응답
+     */
+    @GetMapping("/popular/today")
+    public ResponseEntity<ApiResponse<TodaysPopularStoreResponse>> getTodaysPopularStore() {
+        log.debug("오늘의 인기 매장 조회 요청");
+
+        try {
+            TodaysPopularStoreResponse response = storeDetailService.getTodaysPopularStore();
+            
+            if (response == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail("오늘의 인기 매장 데이터가 없습니다.", 404));
+            }
+            
+            return ResponseEntity.ok(ApiResponse.success(response));
+
+        } catch (Exception e) {
+            log.error("오늘의 인기 매장 조회 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail("오늘의 인기 매장 조회 중 오류가 발생했습니다.", 500));
+        }
     }
 }

--- a/src/main/java/com/example/kakao_login/controller/TestController.java
+++ b/src/main/java/com/example/kakao_login/controller/TestController.java
@@ -2,10 +2,13 @@ package com.example.kakao_login.controller;
 
 import com.example.kakao_login.common.ApiResponse;
 import com.example.kakao_login.repository.StoreRepository;
+import com.example.kakao_login.repository.StoreViewRepository;
+import com.example.kakao_login.repository.EarlybirdDealRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -18,6 +21,8 @@ import java.util.Map;
 public class TestController {
 
     private final StoreRepository storeRepository;
+    private final StoreViewRepository storeViewRepository;
+    private final EarlybirdDealRepository earlybirdDealRepository;
 
     @GetMapping("/stores")
     public ApiResponse<List<Map<String, Object>>> getStores() {
@@ -43,5 +48,89 @@ public class TestController {
             storeRepository.save(store);
         });
         return ApiResponse.success("가비애 매장 외부 링크 정보가 업데이트되었습니다.");
+    }
+
+    /**
+     * 오늘의 조회수 데이터 확인 (테스트용)
+     */
+    @GetMapping("/store-views/today")
+    public ApiResponse<Object> getTodayStoreViews() {
+        java.time.LocalDate today = java.time.LocalDate.now();
+        var views = storeViewRepository.findByViewDateOrderByViewCountDesc(today);
+        
+        var result = new HashMap<String, Object>();
+        result.put("date", today.toString());
+        result.put("total_views", views.size());
+        result.put("views", views.stream().map(view -> {
+            var viewData = new HashMap<String, Object>();
+            viewData.put("store_id", view.getStoreId());
+            viewData.put("view_count", view.getViewCount());
+            return viewData;
+        }).collect(java.util.stream.Collectors.toList()));
+        
+        return ApiResponse.success(result);
+    }
+
+    /**
+     * 조회수 증가 테스트 (테스트용)
+     */
+    @PostMapping("/store-views/increment")
+    public ApiResponse<String> incrementStoreView(@RequestParam String storeId) {
+        // StoreDetailService를 직접 주입받지 않고 여기서 로직 구현
+        try {
+            java.time.LocalDate today = java.time.LocalDate.now();
+            
+            // 기존 조회수 레코드 조회
+            var existingView = storeViewRepository.findByStoreIdAndViewDateAndIsActiveTrue(storeId, today)
+                .orElse(null);
+
+            if (existingView != null) {
+                // 기존 레코드가 있으면 조회수 증가
+                existingView.setViewCount(existingView.getViewCount() + 1);
+                storeViewRepository.save(existingView);
+            } else {
+                // 새 레코드 생성
+                var newView = com.example.kakao_login.entity.StoreView.builder()
+                    .storeId(storeId)
+                    .viewDate(today)
+                    .viewCount(1)
+                    .isActive(true)
+                    .build();
+                storeViewRepository.save(newView);
+            }
+            
+            return ApiResponse.success("조회수가 증가되었습니다. storeId: " + storeId);
+        } catch (Exception e) {
+            return ApiResponse.fail("조회수 증가 실패: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * 매장 할인 정보 확인 (테스트용)
+     */
+    @GetMapping("/store-deals")
+    public ApiResponse<Object> getStoreDeals(@RequestParam String storeId) {
+        // 현재 시간으로 유효한 할인 정보 조회
+        var currentTime = java.time.LocalDateTime.now();
+        var currentDeal = earlybirdDealRepository.findTopCurrentByStoreId(storeId, currentTime);
+        
+        var result = new HashMap<String, Object>();
+        result.put("store_id", storeId);
+        result.put("current_time", currentTime.toString());
+        result.put("has_active_deal", currentDeal.isPresent());
+        
+        if (currentDeal.isPresent()) {
+            var deal = currentDeal.get();
+            var dealData = new HashMap<String, Object>();
+            dealData.put("id", deal.getId());
+            dealData.put("title", deal.getTitle());
+            dealData.put("description", deal.getDescription());
+            dealData.put("status", deal.getStatus());
+            dealData.put("valid_from", deal.getValidFrom());
+            dealData.put("valid_until", deal.getValidUntil());
+            result.put("deal", dealData);
+        }
+        
+        return ApiResponse.success(result);
     }
 }

--- a/src/main/java/com/example/kakao_login/dto/store/TodaysPopularStoreResponse.java
+++ b/src/main/java/com/example/kakao_login/dto/store/TodaysPopularStoreResponse.java
@@ -1,0 +1,62 @@
+package com.example.kakao_login.dto.store;
+
+import com.example.kakao_login.common.ApiResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * 오늘의 인기 매장 응답 DTO
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TodaysPopularStoreResponse(
+    @JsonProperty("store_id")
+    String storeId, // 매장 ID
+    
+    @JsonProperty("store_name")
+    String storeName, // 매장명
+    
+    @JsonProperty("rep_image_url")
+    String repImageUrl, // 대표사진
+    
+    @JsonProperty("business_info")
+    BusinessInfo businessInfo, // 영업 정보
+    
+    @JsonProperty("deal_info")
+    DealInfo dealInfo, // 할인 정보
+    
+    @JsonProperty("rating")
+    Double rating // 평점
+) {
+    /**
+     * 영업 정보 DTO
+     */
+    @Builder
+    public record BusinessInfo(
+        @JsonProperty("status")
+        String status, // 영업 상태 (open, closed, open_24h 등)
+        
+        @JsonProperty("status_message")
+        String statusMessage // 상태 메시지 (24시간 영업, 9시 오픈 등)
+    ) {}
+
+    /**
+     * 할인 정보 DTO
+     */
+    @Builder
+    public record DealInfo(
+        @JsonProperty("title")
+        String title, // 할인 제목
+        
+        @JsonProperty("description")
+        String description // 할인 설명
+    ) {}
+
+    /**
+     * 성공 응답 생성 헬퍼 메서드
+     */
+    public static ApiResponse<TodaysPopularStoreResponse> success(TodaysPopularStoreResponse data) {
+        return ApiResponse.success(data);
+    }
+}

--- a/src/main/java/com/example/kakao_login/entity/StoreView.java
+++ b/src/main/java/com/example/kakao_login/entity/StoreView.java
@@ -1,0 +1,38 @@
+package com.example.kakao_login.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * 매장 조회수 엔티티
+ * - 매장별 일일 조회수를 추적
+ */
+@Entity
+@Table(name = "store_views", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"store_id", "view_date"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreView extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(name = "store_id", nullable = false)
+    private String storeId; // 매장 ID
+
+    @Column(name = "view_date", nullable = false)
+    private LocalDate viewDate; // 조회 날짜
+
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount; // 조회수
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true; // 활성화 여부
+}

--- a/src/main/java/com/example/kakao_login/repository/StoreViewRepository.java
+++ b/src/main/java/com/example/kakao_login/repository/StoreViewRepository.java
@@ -1,0 +1,46 @@
+package com.example.kakao_login.repository;
+
+import com.example.kakao_login.entity.StoreView;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 매장 조회수 Repository
+ */
+@Repository
+public interface StoreViewRepository extends JpaRepository<StoreView, String> {
+
+    /**
+     * 특정 매장의 특정 날짜 조회수 조회
+     */
+    Optional<StoreView> findByStoreIdAndViewDateAndIsActiveTrue(String storeId, LocalDate viewDate);
+
+    /**
+     * 특정 날짜의 모든 매장 조회수 조회 (조회수 내림차순)
+     */
+    @Query("""
+        SELECT sv FROM StoreView sv 
+        WHERE sv.viewDate = :viewDate 
+        AND sv.isActive = true 
+        ORDER BY sv.viewCount DESC
+    """)
+    List<StoreView> findByViewDateOrderByViewCountDesc(@Param("viewDate") LocalDate viewDate);
+
+    /**
+     * 특정 날짜의 최고 조회수 매장 조회
+     */
+    @Query("""
+        SELECT sv FROM StoreView sv 
+        WHERE sv.viewDate = :viewDate 
+        AND sv.isActive = true 
+        ORDER BY sv.viewCount DESC 
+        LIMIT 1
+    """)
+    Optional<StoreView> findTopByViewDateOrderByViewCountDesc(@Param("viewDate") LocalDate viewDate);
+}


### PR DESCRIPTION
### 📌 관련 이슈


---

### ✅ 주요 변경 사항

#### 오늘의 인기 매장 API 구현

* **새로운 엔티티**: `StoreView` - 매장별 일일 조회수 추적
* **새로운 Repository**: `StoreViewRepository` - 조회수 데이터 접근
* **새로운 DTO**: `TodaysPopularStoreResponse` - 오늘의 인기 매장 응답 구조

#### 매장 상세 조회 시 자동 조회수 증가

* `StoreDetailService.getStoreDetail()` 호출 시 자동으로 조회수 증가
* 일별 조회수 데이터 생성 및 업데이트 로직 구현
* 조회수 증가 실패 시에도 전체 요청에 영향 없도록 예외 처리

#### 오늘의 인기 매장 조회 API

* **엔드포인트**: `GET /api/v1/stores/popular/today`
* **기능**: 오늘의 최고 조회수 매장 반환
* **응답 데이터**: 매장 ID, 매장명, 대표사진, 영업정보, 할인정보, 평점

#### 테스트 API 추가

* `GET /api/v1/test/store-views/today` - 오늘의 조회수 데이터 확인
* `POST /api/v1/test/store-views/increment` - 조회수 수동 증가 테스트
* `GET /api/v1/test/store-deals` - 매장 할인 정보 확인

#### 할인 정보 초기화

* 가비애 매장에 "오전시간 커피 무료 사이즈업" 할인 정보 자동 생성
* 오전 6시~10시 100% 할인 (무료 사이즈업) 설정

---

### 기타 참고 사항

* 조회수 증가는 비동기 처리 가능하도록 설계
* 데이터가 없는 경우 404 응답으로 처리
* 기존 main 브랜치 기반으로 깔끔하게 재구현 완료