### PR TITLE
 refactor: 즐겨찾기 목록 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/example/kakao_login/dto/favorite/FavoriteResponse.java
+++ b/src/main/java/com/example/kakao_login/dto/favorite/FavoriteResponse.java
@@ -31,6 +31,15 @@ public class FavoriteResponse {
     ) {}
 
     /**
+     * 할인 정보
+     */
+    @Builder
+    public record DealInfo(
+        String title, // 할인 제목
+        String description // 할인 설명
+    ) {}
+
+    /**
      * 즐겨찾기 매장 정보
      */
     @Builder
@@ -41,16 +50,10 @@ public class FavoriteResponse {
         @JsonProperty("store_name")
         String storeName, // 매장명
         
-        @JsonProperty("visit_count")
-        Integer visitCount, // 방문 횟수
-        
         @JsonProperty("store_image")
         String storeImage, // 매장 대표 이미지
         
-        @JsonProperty("discount_text")
-        String discountText, // 할인 텍스트 (예: "10% 할인 제공")
-        
-        @JsonProperty("sample_menu")
-        String sampleMenu // 대표 메뉴 1개
+        @JsonProperty("deal_info")
+        DealInfo dealInfo // 할인 정보
     ) {}
 }

--- a/src/main/java/com/example/kakao_login/repository/MenuItemRepository.java
+++ b/src/main/java/com/example/kakao_login/repository/MenuItemRepository.java
@@ -28,23 +28,7 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, String> {
         """)
     List<MenuItem> findActiveByStoreIdOrderBySortOrder(@Param("storeId") String storeId);
 
-    /**
-     * 여러 매장의 첫 번째 메뉴 조회 (즐겨찾기 목록용)
-     * @param storeIds 매장 ID 목록
-     * @return 각 매장의 대표 메뉴
-     */
-    @Query("""
-        SELECT m FROM MenuItem m 
-        WHERE m.storeId IN :storeIds 
-        AND m.isActive = true 
-        AND m.sortOrder = (
-            SELECT MIN(m2.sortOrder) FROM MenuItem m2 
-            WHERE m2.storeId = m.storeId 
-            AND m2.isActive = true
-        )
-        ORDER BY m.storeId, m.sortOrder
-        """)
-    List<MenuItem> findFirstMenuByStoreIds(@Param("storeIds") List<String> storeIds);
+
 
     /**
      * 매장의 메뉴 개수 조회


### PR DESCRIPTION
### 📌 관련 이슈


---

### ✅ 주요 변경 사항

#### API 응답 구조 개선

* **`visit_count` 제거**: 방문 횟수 개념 완전 제거
* **`sample_menu` 제거**: 대표 메뉴 개념 완전 제거
* **`discount_text` → `deal_info` 객체로 변경**: 할인 정보를 구조화된 객체로 반환
* **거리 필드 주석 처리**: `distance_meters` 필드를 향후 구현을 위해 주석 처리

#### 코드 정리

* **UserFavoriteService**: 불필요한 메뉴 조회 로직 제거
* **MenuItemRepository**: `findFirstMenuByStoreIds()` 메서드 제거
* **FavoriteResponse**: 새로운 `DealInfo` record 추가 및 필드 정리

#### 응답 예시

```json
{
  "favorite_stores": [
    {
      "store_id": "de44ddba-e42a-47dc-ac27-9b1a5ecbc07e",
      "store_name": "가비애",
      "store_image": "https://github.com/user-attachments/assets/0bd68d92-7695-4dc6-aada-d518e369fcb1",
      "deal_info": {
        "title": "오전시간 커피 무료 사이즈업",
        "description": "오전 6시~10시 방문시 모든 커피 무료 사이즈업!"
      }
    }
  ]
}
```

---

### 기타 참고 사항

* 기존 API와 호환성을 위해 필드 제거 방식으로 진행
* 거리 계산 기능은 향후 위치 기반 서비스 구현 시 추가 예정